### PR TITLE
Fix: cast hr.size to double to avoid warning

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,7 @@ struct HumanReadable {
   private: friend
            inline std::ostream& operator<<(std::ostream& os, HumanReadable hr) {
              int i{};
-             double mantissa = hr.size;
+             double mantissa = (double)hr.size;
              for (; mantissa >= 1024.; mantissa /= 1024., ++i) { }
              mantissa = std::ceil(mantissa * 10.) / 10.;
              os << std::setprecision(3) << mantissa << ' ' << "BKMGTPE"[i];


### PR DESCRIPTION
`hr.size` returns `unsiged long int`, however, `mantissa` variable is a `double`, thus on compilation compiler will emit a warning message. Casting `hr.size` to `double` will fix it.